### PR TITLE
Allow forcing EOS mgm from the config

### DIFF
--- a/cernbox-swan-project
+++ b/cernbox-swan-project
@@ -35,7 +35,7 @@ eos_mgm_url = None
 import cernbox_utils
 
 from cernbox_utils.errors import CmdBadRequestError
-from cernbox_utils.script import get_eos_server, get_eos_server_string
+from cernbox_utils.script import get_eos_server
 
 import os, os.path, sys
 import subprocess

--- a/python/cernbox_utils/db.py
+++ b/python/cernbox_utils/db.py
@@ -100,9 +100,11 @@ class ShareDB:
       if initiator is None:
          initiator=owner
 
-      assert(all(c.isalnum() for c in owner))
-      assert(all(c.isalnum() for c in initiator))
-      assert(all(c.isalnum() or c=='-' for c in sharee)) # egroups may have dash in the name
+      # egroups may have dash in the name
+      # in up2u pilot the usernames have underscore
+      assert(all(c.isalnum() or c=='-' or c=='_' for c in owner))
+      assert(all(c.isalnum() or c=='-' or c=='_' for c in initiator))
+      assert(all(c.isalnum() or c=='-' or c=='_' for c in sharee)) 
 
       if '-' in sharee:
          share_type = 1 # group

--- a/python/cernbox_utils/script.py
+++ b/python/cernbox_utils/script.py
@@ -186,6 +186,12 @@ def get_eos_backend(user):
 
 
 def get_eos_server(user):
+    
+    global config
+    force_eos_mgm = config.get('force_eos_mgm')
+    if force_eos_mgm:
+        return config.get('eos_mgm_url')
+
     backend = get_eos_backend(user)
     return get_eos_server_string(backend)
 

--- a/python/cernbox_utils/script.py
+++ b/python/cernbox_utils/script.py
@@ -154,8 +154,15 @@ class Data(object):
 
 
 def get_eos_backend(user):
-    import redis
+    
     global config
+    # We might not be using redis...
+    if not config.get('redis_host') or \
+        not config.get('redis_port') or \
+        not config.get('redis_password'):
+        return ''
+
+    import redis
 
     logger.debug('getting eos backend for user %s', user)
 
@@ -197,4 +204,7 @@ def get_eos_server(user):
 
 
 def get_eos_server_string(backend):
+    global config
+    if not backend:
+        return config.get('eos_mgm_url')
     return 'root://%s.cern.ch' % ('eosuser-internal' if backend == 'oldhome' else backend)


### PR DESCRIPTION
To avoid the home migration code in the ScienceBox deployment.