### PR TITLE
set acls via cid instead of path

### DIFF
--- a/python/cernbox_utils/cmd_share_admin.py
+++ b/python/cernbox_utils/cmd_share_admin.py
@@ -221,7 +221,7 @@ def verify(args,config,eos,db):
 
          cnt_fix_plaindir = 0
 
-         ns = NSInspect(config)
+         ns = NSInspect(config, logger)
 
          for (file, acls, cid) in ns.inspect(homedir):
             cnt += 1

--- a/python/cernbox_utils/cmd_share_admin.py
+++ b/python/cernbox_utils/cmd_share_admin.py
@@ -223,7 +223,7 @@ def verify(args,config,eos,db):
 
          ns = NSInspect(config)
 
-         for (file, acls) in ns.inspect(homedir):
+         for (file, acls, cid) in ns.inspect(homedir):
             cnt += 1
             try:
                eos_acls = eos.parse_sysacl(acls)
@@ -293,9 +293,9 @@ def verify(args,config,eos,db):
                   expected_acls.extend(shared_acls[sp])
                   shared_directory = True
 
-            expected_acls = cernbox_utils.sharing.squash(set(expected_acls))
+            expected_acls = cernbox_utils.sharing.squashAcls(expected_acls)
 
-            logger.debug(" --- SCAN      --- %s --- %s", file, eos.dump_sysacl(eos_acls))
+            logger.debug(" --- SCAN      --- (cid:%s) %s --- %s", cid, file, eos.dump_sysacl(eos_acls))
 
             dryrun = not args.fix
 
@@ -364,7 +364,7 @@ def verify(args,config,eos,db):
 
                logger.error("FIX_ACL%s: %s %s", msg, file, " ".join([a[0]+" "+eos.dump_sysacl(a[1]) for a in actions]))
 
-               eos_to_check.set_sysacl(file,eos_to_check.dump_sysacl(expected_acls),dryrun=dryrun)
+               eos_to_check.set_sysacl('pid:%s'%cid, eos_to_check.dump_sysacl(expected_acls), dryrun=dryrun)
 
             else:
                pass

--- a/python/cernbox_utils/ns_inspect.py
+++ b/python/cernbox_utils/ns_inspect.py
@@ -20,8 +20,9 @@ eos_machines = {
 
 class NSInspect:
 
-    def __init__(self, config):
+    def __init__(self, config, logger):
         self.config = config
+        self.logger = logger
 
     def _get_eos_machine(self, path):
         
@@ -57,6 +58,7 @@ class NSInspect:
         folders = json.loads(output)
         for folder in folders:
             if 'xattr.sys.acl' not in folder:
+                self.logger.info("Skipping folder without acl: %s" % folder['path'])
                 continue
             to_return.append((folder['path'], folder['xattr.sys.acl'], folder['cid']))
         return to_return

--- a/python/cernbox_utils/sharing.py
+++ b/python/cernbox_utils/sharing.py
@@ -5,11 +5,19 @@ import pwd
 from .script import get_eos_server_string, get_eos_server
 
 # remove duplicates, preserving order
-def squash(seq):
-    seen = set()
-    seen_add = seen.add
-    return [x for x in seq if not (x in seen or seen_add(x))]
+# use the most permissive acl (otherwise EOS picks the first one)
+def squashAcls(acls):
 
+   seen = {}
+
+   for acl in acls:
+      if (acl.entity, acl.name) in seen:
+         if acl.bits != 'rx': #meaning that this acl is at least as permissive (ie rwx+d)
+            seen[(acl.entity, acl.name)] = acl
+      else:
+         seen[(acl.entity, acl.name)] = acl
+
+   return [ seen[key] for key in seen.keys() ]
 
 # convert DB share object inot EOS ACL object
 def share2acl(s):


### PR DESCRIPTION
This prevents crashes with escaped paths
ns-inspect scan instead of dump (deprecated)
ns-inspect output in json