### PR TITLE
Single file shares

### DIFF
--- a/cboxshareadmin.ini
+++ b/cboxshareadmin.ini
@@ -31,8 +31,3 @@ eos_admin_gid = 0
 # 0 => pure owncloud9 schema
 cernboxng_schema_version =
 
-#redis
-redis_host = redis-host
-redis_password = mypass
-redis_port = 1234
-

--- a/cernbox-deepfs.py
+++ b/cernbox-deepfs.py
@@ -22,7 +22,7 @@ from socket import (
 ldap_base = 'OU=Users,OU=Organic Units,DC=cern,DC=ch'
 ldap_query = "(memberof:1.2.840.113556.1.4.1941:=cn=%s,OU=e-groups,OU=Workgroups,DC=cern,DC=ch)"
 
-deep_fs_output = "Overview for user (.*) : scanned (.*) directories, safe fix: (.*) unsafe fix: (.*) plaindir fix: (.*) skipped: (.*) wrong bits: (.*)"
+deep_fs_output = "Overview for user (.*) : scanned (.*) directories/files, safe fix: (.*) unsafe fix: (.*) plaindir fix: (.*) skipped: (.*) wrong bits: (.*)"
 
 
 class DeepFS:

--- a/cernbox-share
+++ b/cernbox-share
@@ -98,6 +98,7 @@ def main():
    subcmd.add_argument("--logdir",default="",action="store",help="log directory")
    subcmd.add_argument("--orphans", default=False, action='store_true', help="check for shares already marked as orphans")
    subcmd.add_argument("--public-links", default=False, action='store_true', help="Check public links as well (if not, it will only check internal shares)")
+   subcmd.add_argument("--with-files", default=False, action='store_true', help="Check single file shares besides folders")
    subcmd.add_argument("shares_owner", help="'-' to check all users in the system")
 
    subcmd = subparser.add_parser('remove-orphan-xbits', help="remove xbits which were set in the initial implementation in the parent ACLs")

--- a/python/cernbox_utils/cmd_share_admin.py
+++ b/python/cernbox_utils/cmd_share_admin.py
@@ -86,6 +86,11 @@ def verify(args,config,eos,db):
       logger.info('Found %d shares of user %s',len(shares),args.shares_owner)
 
       for s in shares:
+
+         if args.project_name and 'project' not in s.fileid_prefix:
+            logger.debug("Skipping share (not a project): %s %s->%s %s %s",s.id,s.uid_owner,s.share_with,s.item_source,quote(s.file_target))
+            continue
+
          fid = s.item_source
 
          logger.debug("Processing share: %s %s->%s %s %s",s.id,s.uid_owner,s.share_with,s.item_source,quote(s.file_target))

--- a/python/cernbox_utils/cmd_share_admin.py
+++ b/python/cernbox_utils/cmd_share_admin.py
@@ -210,7 +210,8 @@ def verify(args,config,eos,db):
             if args.fix:
                   db.set_orphan(s.id, orphan=0)
 
-         if s.share_type != 3:
+         # TODO check guest shares permissions (sys.reva.lwshare.(...)) as well?
+         if s.share_type != 3 and '@' not in s.share_with:
             # this is the expected ACL entry in the shared directory tree
             acl = cernbox_utils.sharing.share2acl(s)
 

--- a/python/cernbox_utils/cmd_share_admin.py
+++ b/python/cernbox_utils/cmd_share_admin.py
@@ -123,7 +123,7 @@ def verify(args,config,eos,db):
                logger.error("FIX: SET_ORPHAN %s",s)
                if args.fix:
                   db.set_orphan(s.id)
-               continue
+            continue
          except:
                logger.error("Error analysing share id=%d owner=%s sharee=%s target='%s' fid=%s",s.id,s.uid_owner,s.share_with,s.file_target,fid)
                continue

--- a/python/cernbox_utils/cmd_share_admin.py
+++ b/python/cernbox_utils/cmd_share_admin.py
@@ -267,7 +267,8 @@ def verify(args,config,eos,db):
 
          # in the rest of this algorithm below we assume that ACL bits belong to a known set
          # modify with care...
-         ALLOWED_ACLS = ['rx','rwx+d','rwx']
+         ## Add 'rxm!dq' so that these are cleaned when fixing. It was a mistake caused by reva, safe to replace
+         ALLOWED_ACLS = ['rx','rwx+d','rwx','rxm!dq', 'rwxm+dq', 'rwx!m', 'rwxm!dq']
 
          def check_allowed(acls, entry):
             for a in acls:

--- a/python/cernbox_utils/cmd_share_admin.py
+++ b/python/cernbox_utils/cmd_share_admin.py
@@ -191,6 +191,8 @@ def verify(args,config,eos,db):
             logger.info("Share type 1 (egroup). Not checking if destination exists")
          elif s.share_type == 3:
             logger.info("Share type 3 (public link). Not checking if destination exists")
+         elif '@' in s.share_with:
+            logger.info("Share with a guest or OCM account. Not checking if destination exists")
          else:
             try:
                pwd.getpwnam(s.share_with)

--- a/python/cernbox_utils/cmd_share_admin.py
+++ b/python/cernbox_utils/cmd_share_admin.py
@@ -209,8 +209,14 @@ def verify(args,config,eos,db):
 
             shared_fids.setdefault(fid,[]).append(acl)
 
-            p = os.path.normpath(f.file)+"/" # append trailing slash, otherwise directories which basename is a substring give false positive, e.g.: /eos/user/k/kuba/tmp.readonly /eos/user/k/kuba/tmp
+            p = os.path.normpath(f.file)
             p = p.decode('utf8')
+
+            if s.item_type == "file":
+               p = p.replace('.sys.v#.', '')
+               logger.info("SINGLE_FILE_SHARE share_id=%s path=%s", s.id, p)
+            else:
+               p += "/" # append trailing slash, otherwise directories which basename is a substring give false positive, e.g.: /eos/user/k/kuba/tmp.readonly /eos/user/k/kuba/tmp
             shared_paths[p] = fid
             shared_acls.setdefault(p,[]).append(acl)
          
@@ -258,158 +264,208 @@ def verify(args,config,eos,db):
 
          cnt_fix_plaindir = 0
 
-         ns = NSInspect(config, logger)
 
-         for (file, acls, cid) in ns.inspect(homedir):
+         # in the rest of this algorithm below we assume that ACL bits belong to a known set
+         # modify with care...
+         ALLOWED_ACLS = ['rx','rwx+d','rwx']
+
+         def check_allowed(acls, entry):
+            for a in acls:
+               if not a.bits in ALLOWED_ACLS:
+                  logger.fatal("ACL bits not allowed: %s %s %s",a, entry, eos.dump_sysacl(acls))
+                  return False
+            return True
+         
+         def is_blacklisted(path):
+            for black_p in blacklist_paths:
+               if path.startswith(black_p):
+                  return True
+            return False
+
+
+         ns = NSInspect(config, logger)
+         folders, files = ns.inspect(homedir, not args.with_files)
+         
+         ## FOLDERS
+         for (folder, acls, cid) in folders:
             cnt += 1
             try:
                eos_acls = eos.parse_sysacl(acls)
 
-               # in the rest of this algorithm below we assume that ACL bits belong to a known set
-               # modify with care...
-               ALLOWED_ACLS = ['rx','rwx+d','rwx']
-
-               def check_allowed():
-                  for a in eos_acls:
-                     if not a.bits in ALLOWED_ACLS:
-                        logger.fatal("ACL bits not allowed: %s %s %s",a, file, eos.dump_sysacl(eos_acls))
-                        return False
-                  return True
-
-               if not check_allowed():
+               if not check_allowed(eos_acls, folder):
                   cnt_wrong_bits += 1
                   cnt_skipped += 1
                   continue
 
-               if is_special_folder(file):
-                  logger.error("Special folder should not have sys.acl set: %s",file)
-                  # FIXME: remove ACL from special folder?
-                  cnt_skipped += 1
-                  continue
-            except KeyError,x:
-               if is_special_folder(file):
-                  continue # skip this entry, it is okey for special folders not to have ACL at all
-               else:
-                  eos_acls = [] # no ACLs defined for this directory
+               if is_special_folder(folder):
+                  logger.error("Special folder should not have sys.acl set: %s",folder)
+
+            except:
+               eos_acls = [] # no ACLs defined for this directory
 
 
             # FIX: u:wwweos:rx
 
             # BLACKLIST FUNCTIONALITY
             # do not touch anything in blacklisted paths: we may not know what to do with them (yet)
-            def is_blacklisted(path):
-               for black_p in blacklist_paths:
-                  if file.startswith(black_p):
-                     return True
-               return False
+            if is_blacklisted(folder):
+               cnt_skipped += 1
+               continue
 
-            if is_blacklisted(file):
+            p = os.path.normpath(folder)
+            shared_directory = False # indicate if the current directory is shared
+
+            if is_special_folder(folder):
+               expected_acls = []
+            else:
+               if args.project_name:
+                  expected_acls = [eos.AclEntry(entity="egroup",name='cernbox-project-%s-writers'%args.project_name, bits="rwx+d"),
+                                    eos.AclEntry(entity="egroup",name='cernbox-project-%s-readers'%args.project_name, bits="rx")]
+
+
+                  if p.startswith(os.path.join(homedir,'www')):
+                     expected_acls += [eos.AclEntry(entity="u",name='83367',bits='rx')] # uid wwweos
+
+               else:
+                  # expected ACL
+                  uid = str(pwd.getpwnam(args.shares_owner).pw_uid)
+                  expected_acls = [eos.AclEntry(entity="u",name=uid,bits="rwx")] # this acl entry should be always set for every directory in homedir
+               
+               p += "/" # add trailing slash to directories, this will make sure that the top-of-shared-directory-tree also matches 
+
+
+               for sp in shared_paths:
+                  if p.startswith(sp): # directory is part of a share tree which has a top at sp
+                     expected_acls.extend(shared_acls[sp])
+                     shared_directory = True
+
+               expected_acls = cernbox_utils.sharing.squashAcls(expected_acls)
+
+            logger.debug(" --- SCAN      --- (cid:%s) %s --- %s", cid, folder, eos.dump_sysacl(eos_acls))
+
+            a, b, c, d = perform_action_analysis('pid:%s'%cid, eos_to_check, eos_acls, expected_acls, shared_directory, folder, eos, args)
+            cnt_fix += a
+            cnt_fix_plaindir += b
+            cnt_safe_fix += c
+            cnt_unsafe_fix += d
+
+
+         ## FILES
+         for (file, acls, fid) in files:
+            cnt += 1
+
+            try:
+               eos_acls = eos.parse_sysacl(acls)
+
+               if not check_allowed(eos_acls, file):
+                  cnt_wrong_bits += 1
+                  cnt_skipped += 1
+                  continue
+            except:
+               eos_acls = [] # no ACLs defined for this file
+
+            # BLACKLIST FUNCTIONALITY
+            # do not touch anything in blacklisted paths: we may not know what to do with them (yet)
+            if is_blacklisted(folder):
                cnt_skipped += 1
                continue
 
             p = os.path.normpath(file)
 
-            if args.project_name:
-               expected_acls = [eos.AclEntry(entity="egroup",name='cernbox-project-%s-writers'%args.project_name, bits="rwx+d"),
-                                 eos.AclEntry(entity="egroup",name='cernbox-project-%s-readers'%args.project_name, bits="rx")]
-
-
-               if p.startswith(os.path.join(homedir,'www')):
-                  expected_acls += [eos.AclEntry(entity="u",name='83367',bits='rx')] # uid wwweos
-
-            else:
-               # expected ACL
-               uid = str(pwd.getpwnam(args.shares_owner).pw_uid)
-               expected_acls = [eos.AclEntry(entity="u",name=uid,bits="rwx")] # this acl entry should be always set for every directory in homedir
-            
-            p += "/" # add trailing slash to directories, this will make sure that the top-of-shared-directory-tree also matches 
-
-            shared_directory = False # indicate if the current directory is shared
-
+            expected_acls = []
+            shared_file = False
             for sp in shared_paths:
-               if p.startswith(sp): # directory is part of a share tree which has a top at sp
+               if p == sp: 
                   expected_acls.extend(shared_acls[sp])
-                  shared_directory = True
+                  shared_file = True
 
             expected_acls = cernbox_utils.sharing.squashAcls(expected_acls)
 
-            logger.debug(" --- SCAN      --- (cid:%s) %s --- %s", cid, file, eos.dump_sysacl(eos_acls))
+            logger.debug(" --- SCAN      --- (fid:%s) %s --- %s", fid, file, eos.dump_sysacl(eos_acls))
 
-            dryrun = not args.fix
-
-            actions = []
-            safe_fix = None # determines if it is "safe" to fix the ACLs (not taking away existing permissions)
-
-            if set(eos_acls) < set(expected_acls):
-               actions.append(("ADD",set(expected_acls)-set(eos_acls)))
-               safe_fix = True
-            elif set(eos_acls) > set(expected_acls):
-               actions.append(("REMOVE",set(eos_acls)-set(expected_acls)))
-               safe_fix = False
-            elif set(eos_acls) != set(expected_acls):
-                  if not args.fix_all_perms:
-                     dryrun = True # do not fix anything like that (unless explicitly specified: --fix-all-perms)
-
-                  safe_fix = False
-
-                  # let's be a bit more specific about the differences
-
-                  added_acls = set(expected_acls)-set(eos_acls)
-                  removed_acls = set(eos_acls)-set(expected_acls)
-
-                  updated_acls = set()
-
-                  def find_acl_by_entity_name(entity,name,acl_list):
-                     for a in acl_list:
-                        if a.entity == entity and a.name == name:
-                           return a
-                     return None
-
-                  for acl1 in removed_acls.copy(): # we may remove from removed_acls set as we iterate over it
-
-                     acl2 = find_acl_by_entity_name(acl1.entity,acl1.name,added_acls)
-
-                     if acl2:
-
-                        if 'rx' in acl1.bits:
-                           safe_fix = True
-
-                        updated_acls.add(eos.AclEntry(entity=acl1.entity,name=acl1.name,bits=acl1.bits+"->"+acl2.bits))
-                        removed_acls.remove(acl1)
-                        added_acls.remove(acl2)
+            a, b, c, d = perform_action_analysis('fid:%s'%fid, eos_to_check, eos_acls, expected_acls, shared_file, file, eos, args)
+            cnt_fix += a
+            cnt_fix_plaindir += b
+            cnt_safe_fix += c
+            cnt_unsafe_fix += d
 
 
-                  if added_acls:
-                     actions.append(("ADD",added_acls))
-                  if removed_acls:
-                     actions.append(("REMOVE",removed_acls))
-                  if updated_acls:
-                     actions.append(("UPDATE",updated_acls))
-                  
-            if actions:
-
-               cnt_fix += 1
-
-               if not shared_directory:
-                  cnt_fix_plaindir += 1
-
-               if safe_fix:
-                  msg = "_SAFE"
-                  cnt_safe_fix +=1
-               else:
-                  msg = ""
-                  cnt_unsafe_fix +=1
-
-               logger.error("FIX_ACL%s: %s %s", msg, file, " ".join([a[0]+" "+eos.dump_sysacl(a[1]) for a in actions]))
-
-               eos_to_check.set_sysacl('pid:%s'%cid, eos_to_check.dump_sysacl(expected_acls), dryrun=dryrun)
-
-            else:
-               pass
-
-         logger.critical("Overview for user %s : scanned %d directories, safe fix: %d unsafe fix: %d plaindir fix: %d skipped: %d wrong bits: %d",args.shares_owner,cnt,cnt_safe_fix,cnt_unsafe_fix,cnt_fix_plaindir,cnt_skipped,cnt_wrong_bits)
+         logger.critical("Overview for user %s : scanned %d directories/files, safe fix: %d unsafe fix: %d plaindir fix: %d skipped: %d wrong bits: %d",args.shares_owner,cnt,cnt_safe_fix,cnt_unsafe_fix,cnt_fix_plaindir,cnt_skipped,cnt_wrong_bits)
             
       return 
+
+def perform_action_analysis(id, eos_to_check, eos_acls, expected_acls, shared_directory, path, eos, args):
+
+      dryrun = not args.fix
+      actions = []
+      safe_fix = None # determines if it is "safe" to fix the ACLs (not taking away existing permissions)
+      cnt_fix, cnt_fix_plaindir, cnt_safe_fix, cnt_unsafe_fix = 0, 0, 0, 0
+
+      if set(eos_acls) < set(expected_acls):
+         actions.append(("ADD",set(expected_acls)-set(eos_acls)))
+         safe_fix = True
+      elif set(eos_acls) > set(expected_acls):
+         actions.append(("REMOVE",set(eos_acls)-set(expected_acls)))
+         safe_fix = False
+      elif set(eos_acls) != set(expected_acls):
+            if not args.fix_all_perms:
+               dryrun = True # do not fix anything like that (unless explicitly specified: --fix-all-perms)
+
+            safe_fix = False
+
+            # let's be a bit more specific about the differences
+
+            added_acls = set(expected_acls)-set(eos_acls)
+            removed_acls = set(eos_acls)-set(expected_acls)
+
+            updated_acls = set()
+
+            def find_acl_by_entity_name(entity,name,acl_list):
+               for a in acl_list:
+                  if a.entity == entity and a.name == name:
+                     return a
+               return None
+
+            for acl1 in removed_acls.copy(): # we may remove from removed_acls set as we iterate over it
+
+               acl2 = find_acl_by_entity_name(acl1.entity,acl1.name,added_acls)
+
+               if acl2:
+
+                  if 'rx' in acl1.bits:
+                     safe_fix = True
+
+                  updated_acls.add(eos.AclEntry(entity=acl1.entity,name=acl1.name,bits=acl1.bits+"->"+acl2.bits))
+                  removed_acls.remove(acl1)
+                  added_acls.remove(acl2)
+
+
+            if added_acls:
+               actions.append(("ADD",added_acls))
+            if removed_acls:
+               actions.append(("REMOVE",removed_acls))
+            if updated_acls:
+               actions.append(("UPDATE",updated_acls))
+            
+      if actions:
+
+         cnt_fix += 1
+
+         if not shared_directory:
+            cnt_fix_plaindir += 1
+
+         if safe_fix:
+            msg = "_SAFE"
+            cnt_safe_fix +=1
+         else:
+            msg = ""
+            cnt_unsafe_fix +=1
+
+         logger.error("FIX_ACL%s: %s %s", msg, path, " ".join([a[0]+" "+eos.dump_sysacl(a[1]) for a in actions]))
+
+         eos_to_check.set_sysacl(id, eos_to_check.dump_sysacl(expected_acls), dryrun=dryrun)
+
+      return cnt_fix, cnt_fix_plaindir, cnt_safe_fix, cnt_unsafe_fix
 
 def remove_orphan_xbits(args,config,eos,db):
       logfn = ""

--- a/python/cernbox_utils/eos.py
+++ b/python/cernbox_utils/eos.py
@@ -102,7 +102,10 @@ class EOS:
         return self.__set_sysacl(path,acl,role,dryrun,'')
 
     def __set_sysacl(self,path,acl,role,dryrun,opt):
-        eos = self._eoscmd("attr",opt,"set","sys.acl=%s"%acl,path,role=role)
+        if acl:
+            eos = self._eoscmd("attr",opt,"set","sys.acl=%s"%acl,path,role=role)
+        else:
+            eos = self._eoscmd("attr",opt,"rm","sys.acl",path,role=role)
         if dryrun:
             logger.warning("would run: %s",eos)
         else:

--- a/python/cernbox_utils/ns_inspect.py
+++ b/python/cernbox_utils/ns_inspect.py
@@ -56,6 +56,7 @@ class NSInspect:
         folders = []
         files = []
 
+        output = output.decode('utf-8','ignore').encode("utf-8")
         entries = json.loads(output)
         for entry in entries:
             if 'cid' in entry:

--- a/python/cernbox_utils/ns_inspect.py
+++ b/python/cernbox_utils/ns_inspect.py
@@ -43,25 +43,29 @@ class NSInspect:
 
         return instance
 
-    def _get_command(self, path):
+    def _get_command(self, path, no_files):
         eos_machine = self._get_eos_machine(path)
-        return "/usr/bin/eos-ns-inspect scan --path %s --members eos%s-qdb:7777 --password-file /keytabs/%s_keytab --no-files --json" % (path, eos_machine, eos_machine)
+        return "/usr/bin/eos-ns-inspect scan --path %s --members eos%s-qdb:7777 --password-file /keytabs/%s_keytab --json%s" % (path, eos_machine, eos_machine, " --no-files" if no_files else "")
 
-    def _run_script(self, path):
-        eos_command = self._get_command(path)
+    def _run_script(self, path, no_files):
+        eos_command = self._get_command(path, no_files)
         # machine_command = "/usr/bin/ssh -oBatchMode=yes -oConnectTimeout=5 -oStrictHostKeyChecking=no -q -l root %s %s" % (self.config['nsinspect-machine'], eos_command)
         return cernbox_utils.script.runcmd(eos_command.split(" "), echo=False, shell=False)
 
     def _parse_output(self, output):
-        to_return = []
+        folders = []
+        files = []
 
-        folders = json.loads(output)
-        for folder in folders:
-            if 'xattr.sys.acl' not in folder:
-                self.logger.info("Skipping folder without acl: %s" % folder['path'])
-                continue
-            to_return.append((folder['path'], folder['xattr.sys.acl'], folder['cid']))
-        return to_return
+        entries = json.loads(output)
+        for entry in entries:
+            if 'cid' in entry:
+                folders.append((entry['path'], entry['xattr.sys.acl'] if 'xattr.sys.acl' in entry else "", entry['cid']))
+            elif 'fid' in entry:
+                files.append((entry['path'], entry['xattr.sys.acl'] if 'xattr.sys.acl' in entry else "", entry['fid']))
+            else:
+                self.logger.info("Skipping path without known type: %s" % entry['path'])
 
-    def inspect(self, path):
-        return self._parse_output(self._run_script(path)[1])
+        return folders, files
+
+    def inspect(self, path, no_files):
+        return self._parse_output(self._run_script(path, no_files)[1])


### PR DESCRIPTION
This checks the ACLs on files as well, so that we add/remove them based on the info in the DB.
It also now cleans all ACLs from special folder like sys.v.

I took many more ACL bits to include some that were added via REVA and that should not be there. So the script will correct them back into `rx` or `rwx`.

I haven't enabled the single file acl check on the script that runs every day (cron)... Let's try first on the users that @gmgigi96 reports and then we'll see.